### PR TITLE
Replace severe warnings with danger zone

### DIFF
--- a/app/assets/stylesheets/content/_notifications.lsg
+++ b/app/assets/stylesheets/content/_notifications.lsg
@@ -46,17 +46,6 @@
 </div>
 ```
 
-## Severe warning
-
-```
-<div class="notification-box -warning -severe">
-  <a href="#" title="close" class="notification-box--close icon-context icon-close2"></a>
-  <div class="notification-box--content">
-    <p>This is a warning with severe consequences. You should not ignore it.</p>
-  </div>
-</div>
-```
-
 ## Success
 
 ```

--- a/app/assets/stylesheets/content/_notifications.sass
+++ b/app/assets/stylesheets/content/_notifications.sass
@@ -153,9 +153,6 @@ $nm-upload-box-padding: rem-calc(15) rem-calc(25)
     &::before
       @include messages-icon
       @extend %nm-icon-warning
-    &.-severe
-      background-color: $nm-color-error-background
-      border-color: $nm-color-error-border
 
   &.-info::before
     @include messages-icon

--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -39,6 +39,7 @@ end
 
 class RepositoriesController < ApplicationController
   include PaginationHelper
+  include RepositoriesHelper
 
   menu_item :repository
   menu_item :settings, only: [:edit, :destroy_info]
@@ -301,10 +302,6 @@ class RepositoriesController < ApplicationController
     else
       flash.now[:error] = @repository.errors.full_messages.join('\n')
     end
-  end
-
-  def settings_repository_tab_path
-    settings_project_path(@project, tab: 'repository')
   end
 
   def find_repository

--- a/app/helpers/repositories_helper.rb
+++ b/app/helpers/repositories_helper.rb
@@ -28,6 +28,10 @@
 #++
 
 module RepositoriesHelper
+  def settings_repository_tab_path
+    settings_project_path(@project, tab: 'repository')
+  end
+
   def format_revision(revision)
     if revision.respond_to? :format_identifier
       revision.format_identifier

--- a/app/views/projects/destroy_info.html.erb
+++ b/app/views/projects/destroy_info.html.erb
@@ -26,21 +26,26 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<%= toolbar title: l(:label_confirmation) %>
-<div class="notification-box -warning -severe">
-  <div class="notification-box--content">
-    <p><strong><%= l(:text_project_destroy_title) %></strong><br />
+<form class="form -bordered -danger-zone">
+  <section class="form--section">
+    <h3 class="form--section-title">
+      <%= l(:text_project_destroy_title) %>
+    </h3>
+    <p>
       <%= l(:text_project_destroy_confirmation, identifier: @project_to_destroy.identifier)%>
       <% if @project_to_destroy.descendants.any? %>
         <br />
-        <%= l(:text_subprojects_destroy_warning, content_tag('strong', h(@project_to_destroy.descendants.collect{|p| p.to_s}.join(', ')))).html_safe %>
+        <% descendants = h(@project_to_destroy.descendants.collect{|p| p.to_s}.join(', ')) %>
+        <%= l(:text_subprojects_destroy_warning, content_tag('strong', descendants.html_safe)) %>
       <% end %>
     </p>
-    <p>
-      <%= styled_form_tag(project_path(@project_to_destroy), method: :delete) do %>
-        <label><%= check_box_tag 'confirm', 1 %> <%= l(:general_text_Yes) %></label>
-        <%= submit_tag l(:button_delete), class: 'button' %>
+    <div>
+      <%= submit_tag l(:button_delete), class: 'button -highlight', title: l(:button_delete) %>
+      <%= link_to admin_projects_path,
+        title: l(:button_cancel),
+        class: 'button' do %>
+        <span class="button--text"><%= l(:button_cancel) %></span>
       <% end %>
-    </p>
-  </div>
-</div>
+    </div>
+  </section>
+</form>

--- a/app/views/repositories/destroy_info.html.erb
+++ b/app/views/repositories/destroy_info.html.erb
@@ -26,28 +26,58 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<%= toolbar title: l(:label_confirmation) %>
-<div class="notification-box -warning <%= @repository.managed? ? '-severe' : '' %>">
+<% if @repository.managed? %>
+<form class="form -bordered -danger-zone">
+  <section class="form--section">
+    <h3 class="form--section-title">
+      <%= l('repositories.destroy.title') %>
+    </h3>
+    <p>
+      <%= l('repositories.destroy.managed_text', project_name: @project.identifier) %>
+      <br/>
+      <%= l('repositories.destroy.managed_path_note', path: @repository.root_url) %>
+    </p>
+    <div>
+      <%= link_to project_repository_path(@project),
+        method: :delete,
+        title: l(:button_delete),
+        class: 'button -highlight' do %>
+        <i class="button--icon icon-delete"></i>
+        <span class="button--text"><%= l(:button_delete) %></span>
+      <% end %>
+      <%= link_to settings_repository_tab_path,
+        title: l(:button_cancel),
+        class: 'button' do %>
+        <i class="button--icon icon-close"></i>
+        <span class="button--text"><%= l(:button_cancel) %></span>
+      <% end %>
+    </div>
+  </section>
+</form>
+<% else %>
+<div class="notification-box -warning">
   <div class="notification-box--content">
     <p><strong><%= l('repositories.destroy.title') %></strong><br /></p>
     <p>
-      <% if @repository.managed? %>
-        <%= l('repositories.destroy.managed_text', project_name: @project.identifier) %>
-        <br/>
-        <%= l('repositories.destroy.managed_path_note', path: @repository.root_url) %>
-      <% else %>
-        <%= simple_format l('repositories.destroy.linked_text',
-                          project_name: @project.identifier, url: @repository.url) %>
-      <% end %>
+      <%= simple_format l('repositories.destroy.linked_text',
+                        project_name: @project.identifier, url: @repository.url) %>
     </p>
     <p>
       <%= link_to project_repository_path(@project),
-        :method => :delete,
-        :class => 'button' do %>
+        title: l(:button_delete),
+        method: :delete,
+        class: 'button' do %>
         <i class="button--icon icon-delete"></i>
         <span class="button--text"><%= l(:button_delete) %></span>
+      <% end %>
+      <%= link_to settings_repository_tab_path,
+        title: l(:button_cancel),
+        class: 'button' do %>
+        <i class="button--icon icon-close"></i>
+        <span class="button--text"><%= l(:button_cancel) %></span>
       <% end %>
     </p>
   </div>
 </div>
+<% end %>
 

--- a/spec/features/repositories/repository_settings_spec.rb
+++ b/spec/features/repositories/repository_settings_spec.rb
@@ -62,8 +62,11 @@ describe 'Repository Settings', type: :feature, js: true do
       find('a.icon-delete', text: I18n.t(:button_delete)).click
 
       # Confirm the notification warning
-      warning = (type == 'managed') ? '-warning.-severe' : '-warning'
-      expect(page).to have_selector(".notification-box.#{warning}")
+      if type == 'managed'
+        expect(page).to have_selector("form.-danger-zone")
+      else
+        expect(page).to have_selector(".notification-box.-warning")
+      end
       find('a', text: I18n.t(:button_delete)).click
 
       vendor = find('select[name="scm_vendor"]')


### PR DESCRIPTION
This commit removes the `.-severe` warning notification type
in favor of the danger zone.
